### PR TITLE
fix: Correct runtime error in backtester

### DIFF
--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -1,9 +1,9 @@
 from typing import Dict
 
-__all__ = ["compute_risk"]
+__all__ = ["calculate_risk_parameters"]
 
 
-def compute_risk(current_price: float, current_atr: float) -> Dict[str, float]:
+def calculate_risk_parameters(current_price: float, current_atr: float) -> Dict[str, float]:
     """
     Calculates stop-loss and take-profit levels based on ATR.
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,16 +1,16 @@
-from src.risk_manager import compute_risk
+from src.risk_manager import calculate_risk_parameters
 
 
 # --- Tests for Risk Manager ---
 
-def test_compute_risk_happy_path() -> None:
+def test_calculate_risk_parameters_happy_path() -> None:
     """Tests standard risk calculation."""
-    params = compute_risk(current_price=100.0, current_atr=5.0)
+    params = calculate_risk_parameters(current_price=100.0, current_atr=5.0)
     assert params["stop_loss"] == 90.0
     assert params["take_profit"] == 120.0
 
-def test_compute_risk_zero_atr() -> None:
+def test_calculate_risk_parameters_zero_atr() -> None:
     """Tests edge case where ATR is zero."""
-    params = compute_risk(current_price=100.0, current_atr=0.0)
+    params = calculate_risk_parameters(current_price=100.0, current_atr=0.0)
     assert params["stop_loss"] == 100.0
     assert params["take_profit"] == 100.0


### PR DESCRIPTION
The backtester script was failing at runtime due to an ImportError. This was caused by a mismatch between the function name called in 'backtester.py' ('calculate_risk_parameters') and the function name defined in 'src/risk_manager.py' ('compute_risk').

This change renames the function in 'src/risk_manager.py' and its corresponding unit tests in 'tests/test_risk.py' to align with the backtester's expectation.

This resolves the ImportError and makes the backtester runnable, restoring the project to a verifiable state as required by H-6.