### PR TITLE
docs: Add README.md with setup and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Project: Emergent Alpha
+
+Emergent Alpha is a decision-support system for identifying 20-day "buy" opportunities in stocks. The core philosophy blends discovering emergent patterns from raw data with a pragmatic focus on simplicity, speed, and using minimal, robust tools.
+
+This MVP provides a deterministic, backtestable pipeline for a single stock ticker.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.10+
+
+### Installation
+
+1.  **Clone the repository:**
+    ```sh
+    git clone <repository-url>
+    cd emergent-alpha
+    ```
+
+2.  **Create and activate a virtual environment:**
+    ```sh
+    python3 -m venv venv
+    source venv/bin/activate
+    # On Windows, use: venv\Scripts\activate
+    ```
+
+3.  **Install the required dependencies:**
+    ```sh
+    pip install -r requirements.txt
+    ```
+
+## Usage
+
+The process involves running a backtest on sample data and then analyzing the results.
+
+1.  **Run the Backtester:**
+    This command will run the backtesting script on the sample Reliance Industries data. It will generate a `results/results.csv` file if any trade signals are found.
+    ```sh
+    python backtester.py --ticker data/ohlcv/RELIANCE.NS.sample.csv
+    ```
+
+2.  **Analyze the Results:**
+    This command reads the output from the backtester and prints a performance summary, including total trades, win rate, and profit factor.
+    ```sh
+    python -m src.analysis.results results/results.csv
+    ```

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -41,3 +41,13 @@ This document records issues, resolutions, and insights gained during the develo
 - **Issue:** The newly created `src/analysis/results.py` script used the `rich` library for formatted console output, following the project's convention for CLI tools. However, `rich` was not listed in `requirements.txt`, causing `pytest` to fail with a `ModuleNotFoundError`.
 - **Resolution:** Added `rich` to `requirements.txt` and re-installed dependencies using `pip install -r requirements.txt`. This resolved the import error and allowed all tests to pass.
 - **Insight:** When adding a new script that has dependencies, even for non-core logic like CLI output, ensure those dependencies are added to `requirements.txt` to maintain a reproducible environment. Rule [H-10] is strict, but a library for rich CLI output is a reasonable addition for a dedicated CLI script.
+
+## 2025-08-16: README Creation and Verification
+
+- **Observation:** Created `README.md` for project setup and usage as per `tasks.md`.
+- **Action:** Manually verified all steps in the `README.md`:
+  - `pip install -r requirements.txt` completed successfully.
+  - `python backtester.py --ticker ...` ran without errors.
+  - `python -m src.analysis.results ...` ran without errors.
+- **Fix:** No fix was required. The instructions were correct.
+- **Learning:** The command `python -m src.analysis.results results/results.csv` is the correct way to invoke the analysis script, which is a good pattern to maintain. The initial project setup and scripts are robust.


### PR DESCRIPTION
Adds a `README.md` file to the project root to provide clear instructions for new developers.

The README includes:
- A brief project overview.
- Steps to set up the Python virtual environment.
- Commands to install dependencies from `requirements.txt`.
- Instructions on how to run the backtester and the analysis script.

The instructions were manually verified to ensure they are correct and produce the expected output. An entry was also added to `docs/memory.md` to log this verification process.