### PR TITLE
docs: Record test environment mismatch in memory.md

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -2,6 +2,12 @@
 
 This document records issues, resolutions, and insights gained during the development of "Emergent Alpha" to prevent repeating mistakes.
 
+## 2025-08-16: Test Environment Mismatch
+
+- **Issue:** Running `pytest -q` failed with `ModuleNotFoundError` for `pandas` and `numpy`, even after `pip install -r requirements.txt` completed successfully. However, running `python -c "import pandas"` worked correctly.
+- **Resolution:** The issue was traced to a potential environment mismatch where the `pytest` command on the system's `PATH` did not belong to the active `pyenv` environment. The problem was resolved by running the tests using `python -m pytest -q`, which ensures that the test runner uses the same Python interpreter where the dependencies were installed. All tests passed with this command.
+- **Insight:** When `pytest` fails to find modules but a direct `python` import works, it's almost always an environment or `PATH` issue. Using `python -m pytest` is a more robust way to run tests as it explicitly ties the execution to the current Python interpreter, avoiding ambiguity. This should be the recommended practice.
+
 ## 2025-08-15: `yfinance` Data Formatting
 
 - **Issue:** The `yfinance.download()` function returns a pandas DataFrame with a multi-level column header (e.g., `('Close', 'RELIANCE.NS')`). When saved directly to CSV, this creates a malformed header that is difficult to parse.


### PR DESCRIPTION
This commit completes Task 8 from docs/tasks.md.

The task required running the unit test suite and fixing any trivial failures. During execution, a test environment mismatch was discovered where `pytest` failed to find installed modules.

The resolution is to use the more robust `python -m pytest` command, which ensures the correct Python interpreter is used. This finding has been documented in `docs/memory.md` as per project guidelines.

No application code was changed because all tests passed after resolving the environment issue.

Net LOC delta: +8
Rationale: Added documentation for a discovered testing issue.