### PR TITLE
Fix: Resolve crewai ImportError and LLM provider issue

### DIFF
--- a/src/adapters/llm.py
+++ b/src/adapters/llm.py
@@ -81,7 +81,7 @@ def get_llm_client() -> ChatOpenAI:
     # potential version incompatibilities with proxy handling in underlying
     # libraries. OpenRouter recommends setting Referer and X-Title headers.
     return ChatOpenAI(
-        model=LLM_MODEL,
+        model=f"openrouter/{LLM_MODEL}" if LLM_MODEL else None,
         openai_api_key=OPENROUTER_API_KEY,
         openai_api_base="https://openrouter.ai/api/v1",
         temperature=0.5,

--- a/src/agents/pattern_analyser.py
+++ b/src/agents/pattern_analyser.py
@@ -95,6 +95,7 @@ def create_pattern_analyser_agent(llm_client: ChatOpenAI) -> Agent:
         llm=llm_client,
         allow_delegation=False,
         verbose=True,  # Set to True for debugging
+        tools=[],
     )
 
 __all__ = ["create_pattern_analyser_agent", "PATTERN_ANALYSER_PROMPT", "format_data_for_llm"]


### PR DESCRIPTION
This commit addresses a series of errors that prevented the backtester from running with the LLM scorer.

The original issue was an `ImportError: cannot import name 'BaseTool' from 'crewai.tools'`, caused by an incompatibility between the installed versions of `crewai` and `crewai_tools`. This was resolved by explicitly passing `tools=[]` to the `crewai.Agent` constructor in `src/agents/pattern_analyser.py`, which avoids triggering the problematic tool initialization logic.

This initial fix revealed a `ModuleNotFoundError` for `langchain_openai`, which was resolved by installing the dependency.

Finally, a `litellm.BadRequestError` occurred because the LLM provider was not specified. This was fixed by prepending `"openrouter/"` to the model name in `src/adapters/llm.py` before it is passed to the LLM client.